### PR TITLE
Remove throw exception

### DIFF
--- a/Block/Checkout/Onepage/Success/PaymentReturn.php
+++ b/Block/Checkout/Onepage/Success/PaymentReturn.php
@@ -87,11 +87,6 @@ class PaymentReturn extends Template
                 $this->paymentReturnData['paymentLogo'] = $this->getViewFileUrl(ConfigVars::ASSET_PATH_CHECKOUT_LOGO_COFIDIS);
                 $this->setTemplate('Ifthenpay_Payment::checkout/onepage/success/cofidisPaymentReturn.phtml');
                 break;
-
-
-            default:
-                throw new \Exception("Unknown Config Class");
-
         }
 
     }


### PR DESCRIPTION
If a customer tries to checkout with a different payment method (eg. any core payment method), an exception is thrown.

fixes #3